### PR TITLE
feat(git): configure git to safer push.default

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -98,8 +98,7 @@
   tool = vimdiff
 
 [push]
-  # possibly simple
-  default = matching
+  default = current
   # Make `git push` push relevant annotated tags when pushing branches out.
   followTags = true
 


### PR DESCRIPTION
Safer default comportement for `git push`

Push the current branch to update a branch with the same name on the receiving end.
