### PR TITLE
feat(brew): homebrew/cask-fonts is deprecated

### DIFF
--- a/home/.chezmoiscripts/mac/run_before_install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/mac/run_before_install-packages.sh.tmpl
@@ -2,7 +2,6 @@
 
 {{- $taps := list
     "hashicorp/tap"
-    "homebrew/cask-fonts"
 -}}
 
 {{- $brews := list


### PR DESCRIPTION
`Error: homebrew/cask-fonts was deprecated. This tap is now empty and all its contents were either deleted or migrated.`