### PR TITLE
feat(node): update node versions list to install

### DIFF
--- a/home/.chezmoiscripts/mac/run_before_install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/mac/run_before_install-packages.sh.tmpl
@@ -56,8 +56,9 @@
 -}}
 
 {{- $nodes := list
-    "lts/gallium"
     "lts/hydrogen"
+    "lts/iron"
+    "lts/jod"
 -}}
 
 {{- if .with_aws -}}


### PR DESCRIPTION
`lts/gallium (v16)` is deprecated
`lts/hydrogen (v18)` is in maintenance
`lts/iron (v20)` is active
`lts/jod (v22)` is current