### PR TITLE
feat(claude): add with_swift flag and template LSP plugins

### DIFF
--- a/.claude/rules/chezmoi.md
+++ b/.claude/rules/chezmoi.md
@@ -60,7 +60,7 @@ Available in `.tmpl` files via `{{ .variable }}`:
 ### Feature flags
 
 - `.with_aws`, `.with_docker`, `.with_golang`, `.with_javascript`
-- `.with_nomad`, `.with_php`, `.with_rust`, `.with_terraform`
+- `.with_nomad`, `.with_php`, `.with_rust`, `.with_swift`, `.with_terraform`
 
 ## Scripts
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,7 @@ jobs:
             with_php = false
             with_terraform = true
             with_rust = true
+            with_swift = true
           EOF
 
       - name: Validate templates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ The configuration uses Go templates with variables defined in `.chezmoi.toml.tmp
 - `with_nomad` - HashiCorp Nomad
 - `with_php` - PHP development tools
 - `with_rust` - Rust development environment
+- `with_swift` - Swift development environment (enables Swift LSP plugin)
 - `with_terraform` - Terraform infrastructure tools
 
 ## Key Components

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -32,6 +32,7 @@
 {{- $with_javascript := false -}}
 {{- $with_php := false -}}
 {{- $with_rust := false -}}
+{{- $with_swift := false -}}
 {{- $with_consul := false -}}
 {{- $with_nomad := false -}}
 {{- $with_packer := false -}}
@@ -113,6 +114,7 @@
 {{-   $with_packer = true -}}
 {{-   $with_php = true -}}
 {{-   $with_rust = true -}}
+{{-   $with_swift = true -}}
 {{-   $with_terraform = true -}}
 {{- end -}}
 
@@ -134,6 +136,7 @@
 {{-   $with_aws = true -}}
 {{-   $with_docker = true -}}
 {{-   $with_javascript = true -}}
+{{-   $with_swift = true -}}
 {{-   $with_terraform = true -}}
 {{- end -}}
 
@@ -164,4 +167,5 @@
     with_packer = {{ $with_packer }}
     with_php = {{ $with_php }}
     with_rust = {{ $with_rust }}
+    with_swift = {{ $with_swift }}
     with_terraform = {{ $with_terraform }}

--- a/home/.chezmoiscripts/tools/run_after_claude_plugins.sh.tmpl
+++ b/home/.chezmoiscripts/tools/run_after_claude_plugins.sh.tmpl
@@ -1,4 +1,4 @@
-{{- if and .is_mac .project_eurosport -}}
+{{- if and .is_mac (or .project_eurosport .with_rust .with_swift) -}}
 #!/bin/bash
 
 set -euo pipefail
@@ -47,22 +47,40 @@ plugin_enabled() {
     echo "${output}" | awk "/❯ ${name}/{found=1} found && /Status:/{print; exit}" | grep -q "✔ enabled"
 }
 
-# Add eurosport marketplace
-if marketplace_exists "eurosport"; then
-    log_info "  Marketplace eurosport already configured"
-else
-    log_info "  Adding marketplace: eurosport..."
-    if claude plugin marketplace add "vbr-tech/eurosport-cc" &>/dev/null; then
-        log_success "  Marketplace eurosport added"
+# Add a marketplace if not already configured
+add_marketplace() {
+    local name="$1"
+    local repo="$2"
+    if marketplace_exists "${name}"; then
+        log_info "  Marketplace ${name} already configured"
     else
-        log_error "  Failed to add marketplace eurosport"
+        log_info "  Adding marketplace: ${name}..."
+        if claude plugin marketplace add "${repo}" &>/dev/null; then
+            log_success "  Marketplace ${name} added"
+        else
+            log_error "  Failed to add marketplace ${name}"
+        fi
     fi
-fi
+}
 
+{{ if .project_eurosport -}}
+add_marketplace "eurosport" "vbr-tech/eurosport-cc"
+{{ end -}}
+{{ if or .with_rust .with_swift -}}
+add_marketplace "claude-plugins-official" "anthropics/claude-plugins-official"
+{{ end }}
 # Plugins to install and enable
 plugins=(
+{{- if .project_eurosport }}
     "eurosport@eurosport"
     "js-to-ts-converter@eurosport"
+{{- end }}
+{{- if .with_rust }}
+    "rust-analyzer-lsp@claude-plugins-official"
+{{- end }}
+{{- if .with_swift }}
+    "swift-lsp@claude-plugins-official"
+{{- end }}
 )
 
 for plugin in "${plugins[@]}"; do

--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -105,11 +105,23 @@
         ]
       }
     ]
-  }{{ if .project_eurosport }},
+  }
+{{- $plugins := list -}}
+{{- if .project_eurosport -}}
+{{-   $plugins = append $plugins "    \"eurosport@eurosport\": true" -}}
+{{-   $plugins = append $plugins "    \"js-to-ts-converter@eurosport\": true" -}}
+{{- end -}}
+{{- if .with_rust -}}
+{{-   $plugins = append $plugins "    \"rust-analyzer-lsp@claude-plugins-official\": true" -}}
+{{- end -}}
+{{- if .with_swift -}}
+{{-   $plugins = append $plugins "    \"swift-lsp@claude-plugins-official\": true" -}}
+{{- end -}}
+{{- if gt (len $plugins) 0 }},
   "enabledPlugins": {
-    "eurosport@eurosport": true,
-    "js-to-ts-converter@eurosport": true
-  }{{ end }},
+{{ join ",\n" $plugins }}
+  }
+{{- end }},
   "skipDangerousModePermissionPrompt": true,
   "effortLevel": "xhigh",
   "autoUpdatesChannel": "latest"


### PR DESCRIPTION
## Summary

- Add new `with_swift` feature flag (true for `project_personal` and `project_mega_lap`)
- Templatize `enabledPlugins` in `home/dot_claude/settings.json.tmpl` so `rust-analyzer-lsp` and `swift-lsp` from `claude-plugins-official` are enabled conditionally on `with_rust` / `with_swift` (eurosport plugins still keyed on `project_eurosport`)
- Extend `run_after_claude_plugins.sh.tmpl` to add the `claude-plugins-official` marketplace (anthropics/claude-plugins-official) and install/enable the LSP plugins automatically; condition broadened to `or .project_eurosport .with_rust .with_swift`
- Update CI mock data, project CLAUDE.md and `.claude/rules/chezmoi.md` accordingly

Motivation: Claude Code had been suggesting LSP plugins manually, leaving a permanent diff on `chezmoi apply`. They are now managed declaratively.

## Test plan

- [ ] `chezmoi init` regenerates local config with `with_swift = true` on personal/mega_lap hosts
- [ ] `chezmoi diff` no longer reports a diff on `~/.claude/settings.json`
- [ ] Rendered settings.json is valid JSON across all flag combinations (verified locally with jq)
- [ ] Rendered `run_after_claude_plugins.sh` passes shellcheck across flag combinations
- [ ] CI lint workflow passes (mock data updated)