### PR TITLE
feat(packages): add Swift tooling conditionally on with_swift flag

### DIFF
--- a/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
+++ b/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
@@ -91,6 +91,18 @@
 {{-   $brews = concat $brews (list "rustup") -}}
 {{- end -}}
 
+{{- if .with_swift -}}
+{{-   $brews = concat $brews (list
+        "swiftformat"
+        "swiftlint"
+        "xcbeautify"
+        "xcodegen"
+        "xcodes"
+    ) -}}
+{{-   $casks = concat $casks (list "sf-symbols") -}}
+{{-   $mas_apps = merge $mas_apps (dict "497799835" "Xcode") -}}
+{{- end -}}
+
 {{- if .with_terraform -}}
 {{-   $brews = concat $brews (list "hashicorp/tap/terraform") -}}
 {{- end -}}

--- a/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
+++ b/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
@@ -97,7 +97,6 @@
         "swiftlint"
         "xcbeautify"
         "xcodegen"
-        "xcodes"
     ) -}}
 {{-   $casks = concat $casks (list "sf-symbols") -}}
 {{-   $mas_apps = merge $mas_apps (dict "497799835" "Xcode") -}}


### PR DESCRIPTION
## Summary

- Adds a `with_swift` conditional block in `run_before_darwin_homebrew.sh.tmpl`
- **Brews:** `swiftformat`, `swiftlint`, `xcbeautify`, `xcodegen`
- **Casks:** `sf-symbols`
- **MAS:** Xcode (ID `497799835`)

## Test plan

- [ ] Vérifier que `chezmoi execute-template '{{ .with_swift }}'` retourne `true` sur une machine `project_personal` ou `project_mega_lap`
- [ ] Vérifier que `chezmoi diff` affiche les packages Swift attendus
- [ ] Vérifier que le lint CI passe (shellcheck, template rendering)