### PR TITLE
chore: tooling audit june 2026

### DIFF
--- a/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
+++ b/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
@@ -26,7 +26,6 @@
     "moreutils"
     "openssl@3"
     "ossianhempel/tap/things3-cli"
-    "reattach-to-user-namespace"
     "ripgrep"
     "sesh"
     "shellcheck"

--- a/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
+++ b/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
@@ -59,7 +59,7 @@
 {{- end -}}
 
 {{- if .with_docker -}}
-{{-   $brews = concat $brews (list "ctop") -}}
+{{-   $brews = concat $brews (list "lazydocker") -}}
 {{-   $casks = concat $casks (list "docker-desktop") -}}
 {{- end -}}
 

--- a/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
+++ b/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
@@ -19,6 +19,7 @@
     "git"
     "gnu-sed"
     "gnu-tar"
+    "gnupg"
     "gum"
     "htop"
     "jq"
@@ -26,6 +27,7 @@
     "moreutils"
     "openssl@3"
     "ossianhempel/tap/things3-cli"
+    "pinentry-mac"
     "ripgrep"
     "sesh"
     "shellcheck"
@@ -48,7 +50,6 @@
     "font-hack"
     "ghostty"
     "google-chrome"
-    "gpg-suite"
     "karabiner-elements"
 -}}
 

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -4,9 +4,6 @@ set -g default-terminal 'screen-256color'
 # Don't detach when destroying a session (switch to another instead)
 set -g detach-on-destroy off
 
-# default startup command
-set-option -g default-command 'reattach-to-user-namespace -l $SHELL -l'
-
 # act like vim
 setw -g mode-keys vi
 bind h select-pane -L
@@ -18,11 +15,11 @@ bind-key -r C-l select-window -t :+
 
 # setup 'v' to begin selection as in Vim
 bind-key -T copy-mode-vi v send -X begin-selection
-bind-key -T copy-mode-vi y send -X copy-pipe 'reattach-to-user-namespace pbcopy'
+bind-key -T copy-mode-vi y send -X copy-pipe 'pbcopy'
 
 # update default binding of `Enter` to also use copy-pipe
 unbind -T copy-mode-vi Enter
-bind-key -T copy-mode-vi Enter send -X copy-pipe 'reattach-to-user-namespace pbcopy'
+bind-key -T copy-mode-vi Enter send -X copy-pipe 'pbcopy'
 
 # reload the file with Prefix r
 bind r source-file ~/.tmux.conf \; display 'Reloaded !'

--- a/home/private_dot_gnupg/private_gpg-agent.conf.tmpl
+++ b/home/private_dot_gnupg/private_gpg-agent.conf.tmpl
@@ -1,5 +1,5 @@
 default-cache-ttl 600
 max-cache-ttl 7200
 {{ if .is_mac }}
-pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
+pinentry-program {{ if .is_apple_silicon }}/opt/homebrew{{ else }}/usr/local{{ end }}/bin/pinentry-mac
 {{- end }}


### PR DESCRIPTION
## Contexte

Audit mensuel (juin 2026) de l'outillage installé par les dotfiles : vérification du statut de maintenance de chaque outil et remplacement de ceux qui sont obsolètes ou abandonnés.

## Changements

- **fix(tmux)** : suppression de `reattach-to-user-namespace` — obsolète depuis tmux 2.6 (2017), upstream mort depuis 2020. Les bindings copy-pipe utilisent `pbcopy` directement.
- **chore(docker)** : `ctop` (abandonné, dernière release 2022) remplacé par `lazydocker` sous le flag `with_docker`.
- **fix(gpg)** : cask `gpg-suite` (stable figée à 2023.3, support Tahoe en bêta uniquement) remplacé par les formules `gnupg` + `pinentry-mac`. `gpg-agent.conf` pointe vers le pinentry Homebrew.

Note : `terminal-notifier` est conservé volontairement — non maintenu mais fonctionnel, aucun enjeu de sécurité (utilitaire purement local).

## ⚠️ Actions manuelles après merge

Retirer un paquet de la liste brew ne le désinstalle pas. Après `chezmoi apply` (qui installera `gnupg`, `pinentry-mac`, `lazydocker`) :

```bash
# 1. Désinstaller les paquets retirés
brew uninstall reattach-to-user-namespace ctop
brew uninstall --cask gpg-suite

# 2. Recharger gpg-agent pour prendre en compte le nouveau pinentry
gpgconf --kill gpg-agent

# 3. Vérifier que la signature GPG fonctionne toujours (clé conservée dans ~/.gnupg)
gpg --list-secret-keys
echo test | gpg --clearsign > /dev/null && echo OK

# 4. Recharger la config tmux (ou redémarrer le serveur tmux)
tmux source-file ~/.tmux.conf
```

À refaire sur chaque machine gérée par chezmoi.