### PR TITLE
chore: tooling audit semaine 29 2026

### DIFF
--- a/home/.chezmoiscripts/editors/run_onchange_after_cursor_extensions.sh.tmpl
+++ b/home/.chezmoiscripts/editors/run_onchange_after_cursor_extensions.sh.tmpl
@@ -34,8 +34,8 @@
 
 {{- if .with_rust -}}
 {{-   $extensions = concat $extensions (list
+        "fill-labs.dependi"
         "rust-lang.rust-analyzer"
-        "serayuzgur.crates"
     ) -}}
 {{- end -}}
 


### PR DESCRIPTION
## Contexte

Audit hebdomadaire (semaine 29, 2026) de l'outillage installé par les dotfiles : formules et casks Homebrew (y compris les blocs conditionnels par feature flag), dépendances externes, plugins vim/tmux, extensions Cursor, scripts `run_after` (node, rust, whisper, serveurs MCP, plugins Claude).

Statuts de dépréciation Homebrew vérifiés sur métadonnées fraîches (`brew update` + API `formulae.brew.sh`, 8483 formules / 7709 casks). Dates de dernier push, statut d'archivage et releases recoupés via `gh api` sur les 42 repos upstream référencés. Extensions Cursor vérifiées via l'API OpenVSX (flag `deprecated`).

**Un seul vrai problème détecté** — une extension Cursor archivée et marquée dépréciée en amont. Le reste de l'outillage est sain ou volontairement conservé.

## Changements

- **fix(cursor)** : `serayuzgur.crates` est **archivé** (repo archivé le 2024-06-29, dernière release v0.6.7 le 2024-07-24) et **marqué `deprecated: true`** sur le marketplace. Son README redirige explicitement vers **Dependi**, le successeur renommé et maintenu par la même équipe. Remplacé par `fill-labs.dependi` (`filllabs/dependi`, dernier push 2026-06-13, v0.7.25) : même gestion des dépendances `Cargo.toml` (versions, lentilles de mise à jour, check de vulnérabilités), et couvre en plus npm/PyPI/Go. Installé sous le feature flag `with_rust` existant.

## Outils volontairement conservés

**Rappels des décisions déjà actées (PR #80, #81)** — non re-questionnées :

- **karabiner-elements** ⚠️ : upstream toujours actif (v16.1.0, 2026-07-05), mais les issues de chargement du driver DriverKit sur Tahoe restent **ouvertes** (#4376, #4409, #4371 — 15 issues Tahoe ouvertes, dernières màj 2026-07-11). Aucun successeur communautaire. Conservé, **toujours sous surveillance** (machines déjà en 26.3.1).
- **terminal-notifier**, **insomnia** : conservés (cf. #80/#81), rien de nouveau.
- **Plugins vim dormants** mais fonctionnels, purement locaux, sans enjeu de sécurité : `mxw/vim-jsx` (2019), `hhff/SpacegrayEighties.vim` (2015), `MarcWeber/vim-addon-mw-utils` (2020), `tomtom/tlib_vim` (2022), `ekalinin/Dockerfile.vim` (2022), `jremmen/vim-ripgrep` (2023), `aliou/bats.vim` (2023), `edkolev/tmuxline.vim` (2023). Aucun repo archivé, aucun 404.
- **Plugins tmux** : `tmux-online-status` (2023) et `tmux-sensible` (2024) dormants mais fonctionnels ; `resurrect` / `yank` / `open` OK.

**Nouveaux constats cette semaine (aucune action requise)** :

- **Extensions Cursor dormantes** mais fonctionnelles et purement locales : `gruntfuggly.todo-tree` (2022-02), `mhutchie.git-graph` (2021-04), `tamasfe.even-better-toml` (2024-12). Non dépréciées, non archivées → conservées.
- **`rangav.vscode-thunder-client`** : bien maintenu (v2.41.0, 2026-06-25) malgré son passage freemium. Aucun enjeu → conservé.
- **`ms-azuretools.vscode-docker`** (v2.0.0, 2025-05) + **`ms-azuretools.vscode-containers`** (v2.4.5, 2026-06) : la scission Microsoft est intentionnelle, les deux extensions sont publiées et non dépréciées.

**Sain, aucune action** :

- **Homebrew** : **aucune** formule ni cask déprécié/désactivé sur les 49 formules et 32 casks référencés (métadonnées fraîches). Tap tiers `ossianhempel/tap` actif (things3-cli v0.3.0, 2026-05-26).
- **Dépendances externes** : `tpm` **v3.1.0** et `vim-plug` **0.14.0** sont bien les **dernières versions taguées**. `prezto` actif (2026-04-24).
- **Serveurs MCP** : `chrome-devtools-mcp` v1.5.0 (2026-07-03) et `@upstash/context7-mcp` v3.2.3 (2026-07-06) — tous deux actifs.
- **whisper.cpp** : l'URL du modèle HuggingFace `ggerganov/whisper.cpp/ggml-medium.bin` répond toujours **HTTP 200**.
- **Node LTS** (`lts/jod` = 22, `lts/krypton` = 24) : aliases valides, Krypton reste le LTS actif (Node 26 ne passera LTS qu'en octobre 2026).

## ⚠️ Actions manuelles après merge

Ce changement ne touche qu'une extension Cursor. Retirer une extension de la liste **ne la désinstalle pas** : `chezmoi apply` installera `fill-labs.dependi`, mais `serayuzgur.crates` restera en place.

```bash
# 1. Appliquer (installe fill-labs.dependi)
chezmoi apply -v

# 2. Désinstaller l'extension dépréciée (non fait par chezmoi)
cursor --uninstall-extension serayuzgur.crates

# 3. Vérifier : dependi présent, crates absent
cursor --list-extensions | grep -E 'dependi|crates'
# → doit afficher uniquement : fill-labs.dependi

# 4. Recharger Cursor pour activer l'extension
#    (Cmd+Shift+P → "Developer: Reload Window")
```

Aucun paquet Homebrew, aucun plugin vim/tmux n'est concerné cette semaine.

**À refaire sur chaque machine gérée par chezmoi** (uniquement celles en `user_veberarnaud` + `with_rust` — Cursor n'est pas déployé sur les machines `user_emmett`).