### PR TITLE
chore: tooling audit semaine 31 2026

### DIFF
--- a/home/dot_nvm/default-packages
+++ b/home/dot_nvm/default-packages
@@ -3,7 +3,6 @@ cost-of-modules
 depcheck
 json-server
 license-checker
-ndb
 npkill
 npm-check-updates
 pnpm

--- a/home/dot_nvm/default-packages
+++ b/home/dot_nvm/default-packages
@@ -1,7 +1,7 @@
 @googleworkspace/cli
 cost-of-modules
-depcheck
 json-server
+knip
 license-checker
 npkill
 npm-check-updates


### PR DESCRIPTION
## Contexte

Audit hebdomadaire (semaine ISO 31, 2026) de l'outillage installé par les dotfiles : formules/casks Homebrew et blocs conditionnels, dépendances externes, plugins vim/tmux, et outils installés par les scripts `run_after` (npm globaux, serveurs MCP, plugins Claude, modèle Whisper).

Statuts de dépréciation Homebrew vérifiés sur métadonnées fraîches (`brew update`, Homebrew 6.0.12) : **aucune formule ni cask déprécié ou désactivé**. Dates de dernier commit/release recoupées via `gh api` et le registre npm.

Le périmètre le moins couvert par les audits précédents — les paquets npm globaux de `home/dot_nvm/default-packages` — a livré les deux seuls problèmes réels de la semaine, tous deux sur des repos **archivés** upstream.

## Changements

- **fix(node)** : suppression de `ndb`. `GoogleChromeLabs/ndb` est **archivé** (dernier push 2022-05-26). Pas seulement dormant — **cassé à l'exécution** : test sur Node 24 / macOS 26, ndb télécharge Chromium r624492 (2019) via `carlo` puis crashe sur `Protocol error (Target.attachToTarget): No target with given id found`. Sa dépendance `carlo` est elle-même archivée depuis 2019, `node-pty@0.9.0-beta18` ne compile plus sous npm 11 (scripts d'install bloqués par défaut), et `npm audit` remonte **15 vulnérabilités dont 12 high** (incl. `puppeteer-core@1.12.2`). Aucun remplaçant ajouté : `node --inspect` / `--inspect-brk` + `chrome://inspect` est intégré à Node et couvre le besoin sans paquet global supplémentaire.
- **chore(node)** : `depcheck` remplacé par `knip`. `depcheck/depcheck` est **archivé** (2025-02-27) et son README s'ouvre sur une dépréciation explicite pointant vers le successeur : « *Depcheck is no longer actively maintained [...] We strongly recommend switching to knip* ». `knip` (webpro-nl/knip, v6.29.0, dernier push 2026-07-25, 11.8k★) couvre le périmètre de depcheck (dépendances inutilisées/manquantes) et y ajoute fichiers et exports morts, avec support TypeScript et monorepo. Vérifié fonctionnel en CLI globale sur Node 24.

## Outils volontairement conservés

**npm globaux dormants mais fonctionnels** (non archivés, purement locaux, sans enjeu de sécurité) — vérifiés à l'exécution sur Node 24 :
- `license-checker` (dernier push 2024-01, publish 2022) — fonctionne, sortie correcte.
- `cost-of-modules` (dernier push 2023-07, publish 2022) — fonctionne.
- `yarn` 1.22.22 : Yarn Classic est en maintenance mais reste la porte d'entrée standard (`yarn set version` pour Berry). Conservé.

**Décisions déjà actées, non re-questionnées** (PR #80, #81) : `terminal-notifier`, `insomnia`, `karabiner-elements` (⚠️ toujours à surveiller sur macOS 26.1+, upstream actif en v16.1.0), et les plugins vim/tmux dormants (`mxw/vim-jsx`, `SpacegrayEighties.vim`, `vim-addon-mw-utils`, `tlib_vim`, `vim-ripgrep`, `Dockerfile.vim`, `html5.vim`, `tmuxline.vim`, `tmux-online-status`, `tmux-sensible`).

**Observation sans action** : `Plug 'bling/vim-airline'` résout par redirection GitHub vers `vim-airline/vim-airline` (le repo canonique a changé d'org). La redirection fonctionne et `PlugInstall` n'est pas cassé → pas de churn. À noter tout de même : si `bling` recréait un dépôt du même nom, la redirection tomberait. Corrigeable en une ligne si tu préfères verrouiller le chemin canonique.

**Reste de l'inventaire — sain** : 48 formules et 33 casks, aucun déprécié/désactivé ; externals `prezto` (2026-04), `tpm` v3.1.0 et `vim-plug` 0.14.0 sont les dernières versions publiées ; serveurs MCP `chrome-devtools-mcp` v1.6.0 et `@upstash/context7-mcp` v3.2.5 actifs ; marketplace `anthropics/claude-plugins-official` actif ; tap `ossianhempel/tap` actif ; URL du modèle Whisper sur HuggingFace répond toujours 200.

## ⚠️ Actions manuelles après merge

Retirer un paquet de `default-packages` ne le désinstalle pas — `nvm` ne l'installe que sur les *nouvelles* versions de Node. Après `chezmoi apply` (qui installera `knip`) :

```bash
# 1. Désinstaller les paquets retirés, sur chaque version de Node installée
for v in $(nvm ls --no-colors --no-alias | grep -o 'v[0-9.]*'); do
    nvm use "$v" >/dev/null
    npm uninstall -g ndb depcheck 2>/dev/null
done

# 2. Installer knip sur la version par défaut si chezmoi ne l'a pas fait
nvm use default
npm install -g knip

# 3. Vérifications
command -v ndb depcheck   # ne doit rien afficher
knip --version            # doit afficher 6.x
node --inspect-brk -e 'console.log(1)'   # remplaçant de ndb (Ctrl-C pour sortir)
```

Aucun paquet Homebrew, plugin vim ou plugin tmux n'est concerné cette semaine — pas de `brew uninstall` ni de `PlugClean` à prévoir.

À refaire sur chaque machine gérée par chezmoi.
