### PR TITLE
feat(android): add with_android feature for native android dev

### DIFF
--- a/.claude/rules/chezmoi.md
+++ b/.claude/rules/chezmoi.md
@@ -59,7 +59,7 @@ Available in `.tmpl` files via `{{ .variable }}`:
 
 ### Feature flags
 
-- `.with_aws`, `.with_docker`, `.with_golang`, `.with_javascript`
+- `.with_android`, `.with_aws`, `.with_docker`, `.with_golang`, `.with_javascript`
 - `.with_nomad`, `.with_php`, `.with_rust`, `.with_swift`, `.with_terraform`
 
 ## Scripts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,7 @@ jobs:
             has_elgato = false
             has_insta360 = false
             has_scanner = false
+            with_android = true
             with_aws = true
             with_consul = false
             with_docker = true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ The configuration uses Go templates with variables defined in `.chezmoi.toml.tmp
 
 ### Feature Flags (conditional installation)
 
+- `with_android` - Android development environment (Android Studio, Temurin JDK)
 - `with_aws` - AWS CLI and tools
 - `with_docker` - Docker and related tools
 - `with_golang` - Go development environment

--- a/docs/superpowers/plans/2026-08-06-android-dev-support.md
+++ b/docs/superpowers/plans/2026-08-06-android-dev-support.md
@@ -1,0 +1,553 @@
+# Android Dev Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `with_android` feature flag that provisions Android Studio, a Temurin 21 JDK and the Android shell environment on `project_mega_lap` machines.
+
+**Architecture:** Follows the existing chezmoi feature-flag pattern: flag declared/derived in `home/.chezmoi.toml.tmpl`, packages added conditionally in the Homebrew script, shell env in a numbered `dot_zprofile.d` drop-in, post-apply check in the verify script. Android Studio's first-launch wizard owns SDK installation (no headless `sdkmanager`).
+
+**Tech Stack:** chezmoi Go templates, bash, Homebrew, GitHub Actions (lint.yml).
+
+**Spec:** `docs/superpowers/specs/2026-08-06-android-dev-support-design.md`
+
+## Global Constraints
+
+- Work in the existing worktree on branch `feature/android-dev-support`; never commit to `main`; final delivery is a PR.
+- Conventional commits `type(scope): subject` — imperative, lowercase, no trailing period, ≤72 chars. Commits are GPG signed (repo default, no extra flag needed).
+- Casks: exactly `android-studio` and `temurin@21`. No brews, no extras (no scrcpy, ktlint, gradle).
+- Drop-in file name: exactly `home/dot_zprofile.d/24-android.sh.tmpl` (slot 24; 23 is whisper).
+- Alphabetical insertion: every new `with_android` block/entry goes immediately BEFORE the corresponding `with_aws` block/entry.
+- `ANDROID_HOME` is `$HOME/Library/Android/sdk` (Android Studio's default SDK location).
+- Verify script checks `java` only — deliberately NOT `adb` (SDK does not exist until first Studio launch).
+- CI mock data (`.github/workflows/lint.yml`) must define `with_android = true` so CI renders and shellchecks the new blocks.
+
+### Template render harness (used by several verification steps)
+
+Each verification step is self-contained: it writes a mock chezmoi config to a
+temp dir and renders templates with it, mirroring what CI does. The function
+below is repeated verbatim in the steps that need it.
+
+```bash
+mkcfg() {
+    # usage: mkcfg true|false  → echoes path of a chezmoi config with with_android set to $1
+    local dir
+    dir="$(mktemp -d)"
+    cat > "${dir}/chezmoi.toml" << EOF
+sourceDir = "${PWD}/home"
+[data]
+    is_mac = true
+    is_linux = false
+    is_windows = false
+    is_unix = true
+    is_apple_silicon = true
+    type_laptop = true
+    type_desktop = false
+    type_server = false
+    user_emmett = false
+    user_veberarnaud = true
+    project_personal = true
+    project_vbr_tech = false
+    project_eurosport = false
+    project_mega_lap = false
+    has_elgato = false
+    has_insta360 = false
+    has_scanner = false
+    with_android = ${1}
+    with_aws = true
+    with_consul = false
+    with_docker = true
+    with_golang = true
+    with_javascript = true
+    with_nomad = false
+    with_packer = false
+    with_php = false
+    with_terraform = true
+    with_rust = true
+    with_swift = true
+EOF
+    echo "${dir}/chezmoi.toml"
+}
+```
+
+All commands run from the worktree root
+(`/Users/veberarnaud/Developer/src/github.com/VEBERArnaud/dotfiles.wt/feature-android-dev-support`).
+
+---
+
+### Task 1: `with_android` flag in chezmoi config and CI mock data
+
+**Files:**
+- Modify: `home/.chezmoi.toml.tmpl`
+- Modify: `.github/workflows/lint.yml`
+- Modify: `docs/superpowers/specs/2026-08-06-android-dev-support-design.md`
+
+**Interfaces:**
+- Produces: template variable `.with_android` (bool), available to every `.tmpl` file. Tasks 2-4 consume it.
+
+- [ ] **Step 1: Verify current state (failing check)**
+
+Run:
+```bash
+chezmoi execute-template < home/.chezmoi.toml.tmpl | grep -c 'with_android' || echo "ABSENT"
+```
+Expected: `0` followed by `ABSENT` (grep finds nothing).
+
+- [ ] **Step 2: Declare the flag in `home/.chezmoi.toml.tmpl`**
+
+In the `{{/* features */}}` block, insert before the `$with_aws` line:
+
+```
+{{- $with_android := false -}}
+```
+
+In the `{{- if $project_mega_lap -}}` block, insert before the `$with_aws` line:
+
+```
+{{-   $with_android = true -}}
+```
+
+In the `[data]` section, insert before the `with_aws` line (indentation: 4 spaces, matching neighbors):
+
+```
+    with_android = {{ $with_android }}
+```
+
+- [ ] **Step 3: Add the flag to CI mock data in `.github/workflows/lint.yml`**
+
+In the `Initialize chezmoi with mock data` step's heredoc, insert before the `with_aws = true` line (same indentation as neighbors):
+
+```
+    with_android = true
+```
+
+- [ ] **Step 4: Sync the spec**
+
+In `docs/superpowers/specs/2026-08-06-android-dev-support-design.md`, in the `## Changes` section, add a subsection after the `### Documentation` subsection:
+
+```markdown
+### `.github/workflows/lint.yml`
+
+Add `with_android = true` to the CI mock `[data]` block (before `with_aws`).
+Without it, templates referencing `.with_android` fail CI rendering with
+"map has no entry for key"; `true` makes CI render and shellcheck the new
+conditional blocks.
+```
+
+- [ ] **Step 5: Verify the flag renders**
+
+Run:
+```bash
+chezmoi execute-template < home/.chezmoi.toml.tmpl | grep -E '^\s*with_android = (true|false)$'
+```
+Expected: exactly one line, `with_android = true` or `with_android = false` depending on the local hostname (true on mega_lap hosts). Any template error means the edit broke the config template.
+
+Also confirm CI mock stays valid TOML-ish and complete:
+```bash
+grep -n 'with_android = true' .github/workflows/lint.yml
+```
+Expected: one match inside the mock data heredoc.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add home/.chezmoi.toml.tmpl .github/workflows/lint.yml docs/superpowers/specs/2026-08-06-android-dev-support-design.md
+git commit -m "feat(android): add with_android feature flag"
+```
+
+---
+
+### Task 2: Homebrew packages (android-studio, temurin@21)
+
+**Files:**
+- Modify: `home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl`
+
+**Interfaces:**
+- Consumes: `.with_android` (Task 1).
+- Produces: rendered Brewfile lines `cask "android-studio"` and `cask "temurin@21"` when the flag is true.
+
+- [ ] **Step 1: Verify current state (failing check)**
+
+```bash
+mkcfg() {
+    local dir
+    dir="$(mktemp -d)"
+    cat > "${dir}/chezmoi.toml" << EOF
+sourceDir = "${PWD}/home"
+[data]
+    is_mac = true
+    is_linux = false
+    is_windows = false
+    is_unix = true
+    is_apple_silicon = true
+    type_laptop = true
+    type_desktop = false
+    type_server = false
+    user_emmett = false
+    user_veberarnaud = true
+    project_personal = true
+    project_vbr_tech = false
+    project_eurosport = false
+    project_mega_lap = false
+    has_elgato = false
+    has_insta360 = false
+    has_scanner = false
+    with_android = ${1}
+    with_aws = true
+    with_consul = false
+    with_docker = true
+    with_golang = true
+    with_javascript = true
+    with_nomad = false
+    with_packer = false
+    with_php = false
+    with_terraform = true
+    with_rust = true
+    with_swift = true
+EOF
+    echo "${dir}/chezmoi.toml"
+}
+chezmoi --config "$(mkcfg true)" execute-template \
+    < home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl \
+    | grep -c 'android-studio' || echo "ABSENT"
+```
+Expected: `0` followed by `ABSENT`.
+
+- [ ] **Step 2: Add the conditional block**
+
+In `home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl`, insert immediately before the `{{- if .with_aws -}}` block:
+
+```
+{{- if .with_android -}}
+{{-   $casks = concat $casks (list
+        "android-studio"
+        "temurin@21"
+    ) -}}
+{{- end -}}
+
+```
+
+(Trailing blank line matches the spacing between existing blocks.)
+
+- [ ] **Step 3: Verify rendering, both flag values, and shellcheck**
+
+```bash
+mkcfg() {
+    local dir
+    dir="$(mktemp -d)"
+    cat > "${dir}/chezmoi.toml" << EOF
+sourceDir = "${PWD}/home"
+[data]
+    is_mac = true
+    is_linux = false
+    is_windows = false
+    is_unix = true
+    is_apple_silicon = true
+    type_laptop = true
+    type_desktop = false
+    type_server = false
+    user_emmett = false
+    user_veberarnaud = true
+    project_personal = true
+    project_vbr_tech = false
+    project_eurosport = false
+    project_mega_lap = false
+    has_elgato = false
+    has_insta360 = false
+    has_scanner = false
+    with_android = ${1}
+    with_aws = true
+    with_consul = false
+    with_docker = true
+    with_golang = true
+    with_javascript = true
+    with_nomad = false
+    with_packer = false
+    with_php = false
+    with_terraform = true
+    with_rust = true
+    with_swift = true
+EOF
+    echo "${dir}/chezmoi.toml"
+}
+tmpl=home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
+chezmoi --config "$(mkcfg true)" execute-template < "$tmpl" | grep 'cask "android-studio"'
+chezmoi --config "$(mkcfg true)" execute-template < "$tmpl" | grep 'cask "temurin@21"'
+chezmoi --config "$(mkcfg false)" execute-template < "$tmpl" | grep -c 'android' || echo "OK-ABSENT-WHEN-FALSE"
+chezmoi --config "$(mkcfg true)" execute-template < "$tmpl" | shellcheck -s bash -e SC1091 -
+```
+Expected: the two casks greps match one line each; then `0` followed by `OK-ABSENT-WHEN-FALSE`; shellcheck exits 0 with no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
+git commit -m "feat(android): install android studio and temurin jdk via brew"
+```
+
+---
+
+### Task 3: Shell environment drop-in
+
+**Files:**
+- Create: `home/dot_zprofile.d/24-android.sh.tmpl`
+
+**Interfaces:**
+- Consumes: `.with_android` (Task 1).
+- Produces: `~/.zprofile.d/24-android.sh` exporting `ANDROID_HOME`, PATH entries, `JAVA_HOME` (empty file when flag is false).
+
+- [ ] **Step 1: Create `home/dot_zprofile.d/24-android.sh.tmpl`**
+
+Exact content:
+
+```bash
+{{- if .with_android }}
+# Android
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export PATH="$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator"
+if JAVA_HOME="$(/usr/libexec/java_home -v 21 2>/dev/null)"; then
+    export JAVA_HOME
+fi
+{{- end }}
+```
+
+- [ ] **Step 2: Verify rendering for both flag values**
+
+```bash
+mkcfg() {
+    local dir
+    dir="$(mktemp -d)"
+    cat > "${dir}/chezmoi.toml" << EOF
+sourceDir = "${PWD}/home"
+[data]
+    with_android = ${1}
+EOF
+    echo "${dir}/chezmoi.toml"
+}
+tmpl=home/dot_zprofile.d/24-android.sh.tmpl
+chezmoi --config "$(mkcfg true)" execute-template < "$tmpl" | grep 'ANDROID_HOME'
+chezmoi --config "$(mkcfg true)" execute-template < "$tmpl" | shellcheck -s bash -
+test -z "$(chezmoi --config "$(mkcfg false)" execute-template < "$tmpl" | tr -d '[:space:]')" && echo "EMPTY-WHEN-FALSE"
+```
+Expected: two `ANDROID_HOME` grep hits (export + PATH lines), shellcheck silent, `EMPTY-WHEN-FALSE` printed.
+
+(The minimal `[data]` block works here because this template only references `.with_android`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add home/dot_zprofile.d/24-android.sh.tmpl
+git commit -m "feat(android): add android shell environment drop-in"
+```
+
+---
+
+### Task 4: Post-apply verification check
+
+**Files:**
+- Modify: `home/.chezmoiscripts/verify/run_after_verify.sh.tmpl`
+
+**Interfaces:**
+- Consumes: `.with_android` (Task 1); `check_command_available` and `log_info` from `common.tmpl` (already used throughout the file).
+
+- [ ] **Step 1: Add the conditional block**
+
+In `home/.chezmoiscripts/verify/run_after_verify.sh.tmpl`, in the `# Conditional commands` section, insert immediately before the `{{ if .with_aws -}}` block:
+
+```
+{{ if .with_android -}}
+echo ""
+log_info "Checking Android tools..."
+check_command_available java || errors=$((errors + 1))
+{{ end -}}
+```
+
+- [ ] **Step 2: Verify rendering, both flag values, and shellcheck**
+
+```bash
+mkcfg() {
+    local dir
+    dir="$(mktemp -d)"
+    cat > "${dir}/chezmoi.toml" << EOF
+sourceDir = "${PWD}/home"
+[data]
+    is_mac = true
+    is_linux = false
+    is_windows = false
+    is_unix = true
+    is_apple_silicon = true
+    type_laptop = true
+    type_desktop = false
+    type_server = false
+    user_emmett = false
+    user_veberarnaud = true
+    project_personal = true
+    project_vbr_tech = false
+    project_eurosport = false
+    project_mega_lap = false
+    has_elgato = false
+    has_insta360 = false
+    has_scanner = false
+    with_android = ${1}
+    with_aws = true
+    with_consul = false
+    with_docker = true
+    with_golang = true
+    with_javascript = true
+    with_nomad = false
+    with_packer = false
+    with_php = false
+    with_terraform = true
+    with_rust = true
+    with_swift = true
+EOF
+    echo "${dir}/chezmoi.toml"
+}
+tmpl=home/.chezmoiscripts/verify/run_after_verify.sh.tmpl
+chezmoi --config "$(mkcfg true)" execute-template < "$tmpl" | grep 'Checking Android tools'
+chezmoi --config "$(mkcfg false)" execute-template < "$tmpl" | grep -c 'Android' || echo "OK-ABSENT-WHEN-FALSE"
+chezmoi --config "$(mkcfg true)" execute-template < "$tmpl" | shellcheck -s bash -e SC1091 -
+```
+Expected: first grep matches; then `0` followed by `OK-ABSENT-WHEN-FALSE`; shellcheck silent.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add home/.chezmoiscripts/verify/run_after_verify.sh.tmpl
+git commit -m "feat(android): check java in post-apply verification"
+```
+
+---
+
+### Task 5: Documentation (flag lists)
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `.claude/rules/chezmoi.md`
+
+**Interfaces:** none (documentation only).
+
+- [ ] **Step 1: Update `CLAUDE.md`**
+
+In the `### Feature Flags (conditional installation)` section, insert before the `with_aws` line:
+
+```markdown
+- `with_android` - Android development environment (Android Studio, Temurin JDK)
+```
+
+- [ ] **Step 2: Update `.claude/rules/chezmoi.md`**
+
+In the `### Feature flags` section, the current first line is:
+
+```markdown
+- `.with_aws`, `.with_docker`, `.with_golang`, `.with_javascript`
+```
+
+Replace it with:
+
+```markdown
+- `.with_android`, `.with_aws`, `.with_docker`, `.with_golang`, `.with_javascript`
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n 'with_android' CLAUDE.md .claude/rules/chezmoi.md
+```
+Expected: one match in each file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md .claude/rules/chezmoi.md
+git commit -m "docs(android): document with_android feature flag"
+```
+
+---
+
+### Task 6: Push branch and open PR
+
+**Files:** none (git/GitHub only).
+
+- [ ] **Step 1: Full local validation sweep (mirror CI)**
+
+```bash
+mkcfg() {
+    local dir
+    dir="$(mktemp -d)"
+    cat > "${dir}/chezmoi.toml" << EOF
+sourceDir = "${PWD}/home"
+[data]
+    is_mac = true
+    is_linux = false
+    is_windows = false
+    is_unix = true
+    is_apple_silicon = true
+    type_laptop = true
+    type_desktop = false
+    type_server = false
+    user_emmett = false
+    user_veberarnaud = true
+    project_personal = true
+    project_vbr_tech = false
+    project_eurosport = false
+    project_mega_lap = false
+    has_elgato = false
+    has_insta360 = false
+    has_scanner = false
+    with_android = true
+    with_aws = true
+    with_consul = false
+    with_docker = true
+    with_golang = true
+    with_javascript = true
+    with_nomad = false
+    with_packer = false
+    with_php = false
+    with_terraform = true
+    with_rust = true
+    with_swift = true
+EOF
+    echo "${dir}/chezmoi.toml"
+}
+cfg="$(mkcfg true)"
+chezmoi --config "${cfg}" diff > /dev/null && echo "TEMPLATES-OK"
+find home/.chezmoiscripts -name "*.sh.tmpl" | while read -r tmpl; do
+    chezmoi --config "${cfg}" execute-template < "${tmpl}" | shellcheck -s bash -e SC1091 - || echo "FAIL: ${tmpl}"
+done
+echo "SHELLCHECK-DONE"
+```
+Expected: `TEMPLATES-OK`, then `SHELLCHECK-DONE` with no `FAIL:` lines.
+
+Note: `chezmoi diff` with the mock config compares against the real `$HOME` — output content is irrelevant, only a zero exit (no template error) matters, hence `> /dev/null`.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin feature/android-dev-support
+gh pr create \
+    --title "feat(android): add with_android feature for native android dev" \
+    --body "$(cat << 'EOF'
+## Summary
+
+Adds a `with_android` feature flag (enabled for `project_mega_lap`) that
+provisions native Android development:
+
+- Casks `android-studio` + `temurin@21` via the Homebrew script
+- `~/.zprofile.d/24-android.sh`: `ANDROID_HOME`, platform-tools/emulator in
+  PATH, guarded `JAVA_HOME`
+- `java` check in the post-apply verify script (no `adb` check — the SDK only
+  exists after Android Studio's first-launch wizard)
+- CI mock data gains `with_android = true` so the new blocks are rendered and
+  shellchecked
+
+Spec: `docs/superpowers/specs/2026-08-06-android-dev-support-design.md`
+Plan: `docs/superpowers/plans/2026-08-06-android-dev-support.md`
+
+## Manual step after merge + chezmoi apply
+
+Launch Android Studio once; its setup wizard installs the SDK,
+platform-tools and emulator into `~/Library/Android/sdk`.
+EOF
+)"
+```
+Expected: PR created against `main`, CI (Lint & Validate) green.

--- a/docs/superpowers/plans/2026-08-06-android-dev-support.md
+++ b/docs/superpowers/plans/2026-08-06-android-dev-support.md
@@ -349,6 +349,8 @@ git commit -m "feat(android): add android shell environment drop-in"
 **Interfaces:**
 - Consumes: `.with_android` (Task 1); `check_command_available` and `log_info` from `common.tmpl` (already used throughout the file).
 
+Amended after final review: the check uses `/usr/libexec/java_home -v 21` because macOS's `/usr/bin/java` stub makes `command -v java` always succeed.
+
 - [ ] **Step 1: Add the conditional block**
 
 In `home/.chezmoiscripts/verify/run_after_verify.sh.tmpl`, in the `# Conditional commands` section, insert immediately before the `{{ if .with_aws -}}` block:
@@ -357,7 +359,12 @@ In `home/.chezmoiscripts/verify/run_after_verify.sh.tmpl`, in the `# Conditional
 {{ if .with_android -}}
 echo ""
 log_info "Checking Android tools..."
-check_command_available java || errors=$((errors + 1))
+if /usr/libexec/java_home -v 21 &>/dev/null; then
+    log_success "java 21 available"
+else
+    log_error "java 21 not found"
+    errors=$((errors + 1))
+fi
 {{ end -}}
 ```
 

--- a/docs/superpowers/specs/2026-08-06-android-dev-support-design.md
+++ b/docs/superpowers/specs/2026-08-06-android-dev-support-design.md
@@ -93,6 +93,13 @@ Studio launch, so an `adb` check would fail on a fresh machine.
 - `CLAUDE.md`: add `with_android` to the feature flags list.
 - `.claude/rules/chezmoi.md`: add `.with_android` to the feature flags list.
 
+### `.github/workflows/lint.yml`
+
+Add `with_android = true` to the CI mock `[data]` block (before `with_aws`).
+Without it, templates referencing `.with_android` fail CI rendering with
+"map has no entry for key"; `true` makes CI render and shellcheck the new
+conditional blocks.
+
 ## Manual step (documented, not automated)
 
 After `chezmoi apply`, launch Android Studio once; its setup wizard installs

--- a/docs/superpowers/specs/2026-08-06-android-dev-support-design.md
+++ b/docs/superpowers/specs/2026-08-06-android-dev-support-design.md
@@ -1,0 +1,114 @@
+# android: native Android development support via with_android
+
+**Date:** 2026-08-06
+**Target:** `home/.chezmoi.toml.tmpl`, `home/.chezmoiscripts/`, `home/dot_zprofile.d/`
+
+## Problem
+
+The dotfiles provision toolchains per feature flag (`with_golang`, `with_rust`,
+`with_swift`, ...) but have no Android support. Native Kotlin/Java Android
+development is starting on the Mega Lap project, which already carries
+`with_swift` for the iOS side. Machines need Android Studio, a JDK usable from
+the terminal, and shell environment (`ANDROID_HOME`, `adb`/`emulator` in PATH)
+without manual setup.
+
+## Goals
+
+1. A `with_android` feature flag following the existing flag conventions,
+   enabled for `project_mega_lap` (MacBookPro2023, MacMini2023s).
+2. Android Studio and a JDK installed via the Homebrew script.
+3. Shell environment ready for terminal workflows (`adb`, `emulator`, Gradle
+   wrapper builds) once the SDK exists.
+
+## Design decisions
+
+- **Native Kotlin/Java stack** — no React Native / Flutter / KMP tooling.
+- **Android Studio manages the SDK.** The first-launch wizard installs the SDK,
+  platform-tools and emulator into `~/Library/Android/sdk`. No headless
+  `sdkmanager` scripting, no license automation to maintain.
+- **JDK: `temurin@21` cask** (LTS, compatible with current AGP/Gradle). Android
+  Studio bundles its own JBR for the IDE; the system JDK serves terminal
+  `./gradlew` builds. It is a pkg installer, so `chezmoi apply` may prompt for
+  the sudo password once.
+- **No extras** (scrcpy, ktlint, standalone gradle) — YAGNI, added later if
+  needed.
+
+## Changes
+
+### `home/.chezmoi.toml.tmpl`
+
+- Declare `{{- $with_android := false -}}` in the features block (alphabetical
+  position, first).
+- Set `{{- $with_android = true -}}` in the `project_mega_lap` block.
+- Export `with_android = {{ $with_android }}` in `[data]`.
+
+### `home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl`
+
+New conditional block, inserted before `with_aws`:
+
+```
+{{- if .with_android -}}
+{{-   $casks = concat $casks (list "android-studio" "temurin@21") -}}
+{{- end -}}
+```
+
+### `home/dot_zprofile.d/24-android.sh.tmpl` (new)
+
+Slot 24 — next free in the 20-29 languages/runtimes range (23 is whisper).
+
+```bash
+{{- if .with_android }}
+# Android
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export PATH="$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator"
+if JAVA_HOME="$(/usr/libexec/java_home -v 21 2>/dev/null)"; then
+    export JAVA_HOME
+fi
+{{- end }}
+```
+
+- `ANDROID_HOME` points at Android Studio's default SDK location; the PATH
+  entries are harmless before the SDK exists and active right after the
+  first-launch wizard.
+- The `JAVA_HOME` guard avoids exporting an empty variable when the JDK is not
+  installed yet.
+
+### `home/.chezmoiscripts/verify/run_after_verify.sh.tmpl`
+
+New conditional block (alphabetical, before `with_aws`):
+
+```
+{{ if .with_android -}}
+echo ""
+log_info "Checking Android tools..."
+check_command_available java || errors=$((errors + 1))
+{{ end -}}
+```
+
+Deliberately no `adb` check: the SDK only exists after the first Android
+Studio launch, so an `adb` check would fail on a fresh machine.
+
+### Documentation
+
+- `CLAUDE.md`: add `with_android` to the feature flags list.
+- `.claude/rules/chezmoi.md`: add `.with_android` to the feature flags list.
+
+## Manual step (documented, not automated)
+
+After `chezmoi apply`, launch Android Studio once; its setup wizard installs
+the SDK, platform-tools and emulator into `~/Library/Android/sdk`.
+
+## Out of scope
+
+- Headless SDK provisioning (`android-commandlinetools`, `sdkmanager`,
+  license acceptance scripting).
+- Extra CLI tools (scrcpy, ktlint, standalone gradle).
+- Enabling `with_android` for other projects or hosts.
+
+## Testing
+
+- CI must pass: template rendering of all `.tmpl` files, ShellCheck.
+- `chezmoi execute-template` renders the new drop-in for a mega_lap host
+  (block present) and a non-mega_lap host (empty file).
+- On a mega_lap machine after apply: `echo $ANDROID_HOME` set, `java -version`
+  works, and after the Studio wizard `adb --version` works.

--- a/docs/superpowers/specs/2026-08-06-android-dev-support-design.md
+++ b/docs/superpowers/specs/2026-08-06-android-dev-support-design.md
@@ -81,9 +81,17 @@ New conditional block (alphabetical, before `with_aws`):
 {{ if .with_android -}}
 echo ""
 log_info "Checking Android tools..."
-check_command_available java || errors=$((errors + 1))
+if /usr/libexec/java_home -v 21 &>/dev/null; then
+    log_success "java 21 available"
+else
+    log_error "java 21 not found"
+    errors=$((errors + 1))
+fi
 {{ end -}}
 ```
+
+The check verifies JDK 21 via `/usr/libexec/java_home` because macOS's
+`/usr/bin/java` stub makes a bare `command -v java` check vacuous.
 
 Deliberately no `adb` check: the SDK only exists after the first Android
 Studio launch, so an `adb` check would fail on a fresh machine.
@@ -117,5 +125,6 @@ the SDK, platform-tools and emulator into `~/Library/Android/sdk`.
 - CI must pass: template rendering of all `.tmpl` files, ShellCheck.
 - `chezmoi execute-template` renders the new drop-in for a mega_lap host
   (block present) and a non-mega_lap host (empty file).
-- On a mega_lap machine after apply: `echo $ANDROID_HOME` set, `java -version`
-  works, and after the Studio wizard `adb --version` works.
+- On a mega_lap machine after apply: `echo $ANDROID_HOME` set,
+  `/usr/libexec/java_home -v 21` succeeds, and after the Studio wizard
+  `adb --version` works.

--- a/documentation/shell-environment.md
+++ b/documentation/shell-environment.md
@@ -54,6 +54,7 @@ The `(N)` glob qualifier ensures no error if the directory is empty. Files are s
 | `21-javascript.sh.tmpl` | Yes      | `.with_javascript`                     | Loads nvm, auto-switches Node via `chpwd` hook on `.nvmrc` |
 | `22-rust.sh.tmpl`       | Yes      | `.with_rust`                           | Adds `~/.cargo/bin` to PATH                                |
 | `23-whisper.sh.tmpl`    | Yes      | `.is_apple_silicon` AND `.user_emmett` | Sets Metal acceleration path for whisper-cpp               |
+| `24-android.sh.tmpl`    | Yes      | `.with_android`                        | Sets `ANDROID_HOME`, PATH; guarded `JAVA_HOME` (JDK 21)    |
 | `30-mysql.sh`           | No       | —                                      | Configures MySQL prompt format                             |
 | `40-direnv.sh`          | No       | —                                      | Hooks direnv into zsh                                      |
 | `41-fzf.sh`             | No       | —                                      | Sets fzf default command to `rg --files --hidden`          |

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -26,6 +26,7 @@
 {{- $has_scanner := false -}}
 
 {{/* features */}}
+{{- $with_android := false -}}
 {{- $with_aws := false -}}
 {{- $with_docker := false -}}
 {{- $with_golang := false -}}
@@ -134,6 +135,7 @@
 {{- end -}}
 
 {{- if $project_mega_lap -}}
+{{-   $with_android = true -}}
 {{-   $with_aws = true -}}
 {{-   $with_docker = true -}}
 {{-   $with_javascript = true -}}
@@ -159,6 +161,7 @@
     has_elgato = {{ $has_elgato }}
     has_insta360 = {{ $has_insta360 }}
     has_scanner = {{ $has_scanner }}
+    with_android = {{ $with_android }}
     with_aws = {{ $with_aws }}
     with_docker = {{ $with_docker }}
     with_golang = {{ $with_golang }}

--- a/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
+++ b/home/.chezmoiscripts/packages/run_before_darwin_homebrew.sh.tmpl
@@ -56,6 +56,13 @@
 
 {{- $mas_apps := dict -}}
 
+{{- if .with_android -}}
+{{-   $casks = concat $casks (list
+        "android-studio"
+        "temurin@21"
+    ) -}}
+{{- end -}}
+
 {{- if .with_aws -}}
 {{-   $brews = concat $brews (list "awscli") -}}
 {{- end -}}

--- a/home/.chezmoiscripts/verify/run_after_verify.sh.tmpl
+++ b/home/.chezmoiscripts/verify/run_after_verify.sh.tmpl
@@ -68,7 +68,12 @@ check_command_available terminal-notifier || errors=$((errors + 1))
 {{ if .with_android -}}
 echo ""
 log_info "Checking Android tools..."
-check_command_available java || errors=$((errors + 1))
+if /usr/libexec/java_home -v 21 &>/dev/null; then
+    log_success "java 21 available"
+else
+    log_error "java 21 not found"
+    errors=$((errors + 1))
+fi
 {{ end -}}
 {{ if .with_aws -}}
 echo ""

--- a/home/.chezmoiscripts/verify/run_after_verify.sh.tmpl
+++ b/home/.chezmoiscripts/verify/run_after_verify.sh.tmpl
@@ -65,6 +65,11 @@ check_command_available shellcheck || errors=$((errors + 1))
 check_command_available terminal-notifier || errors=$((errors + 1))
 
 # Conditional commands
+{{ if .with_android -}}
+echo ""
+log_info "Checking Android tools..."
+check_command_available java || errors=$((errors + 1))
+{{ end -}}
 {{ if .with_aws -}}
 echo ""
 log_info "Checking AWS tools..."

--- a/home/dot_zprofile.d/24-android.sh.tmpl
+++ b/home/dot_zprofile.d/24-android.sh.tmpl
@@ -1,0 +1,8 @@
+{{- if .with_android }}
+# Android
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export PATH="$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator"
+if JAVA_HOME="$(/usr/libexec/java_home -v 21 2>/dev/null)"; then
+    export JAVA_HOME
+fi
+{{- end }}


### PR DESCRIPTION
## Summary

Adds a `with_android` feature flag (enabled for `project_mega_lap`) that
provisions native Android development:

- Casks `android-studio` + `temurin@21` via the Homebrew script
- `~/.zprofile.d/24-android.sh`: `ANDROID_HOME`, platform-tools/emulator in
  PATH, guarded `JAVA_HOME`
- JDK 21 check in the post-apply verify script via `/usr/libexec/java_home
  -v 21` (a bare `command -v java` check is vacuous on macOS because of the
  `/usr/bin/java` stub); no `adb` check — the SDK only exists after Android
  Studio's first-launch wizard
- CI mock data gains `with_android = true` so the new blocks are rendered and
  shellchecked
- Documentation updates: feature-flag lists (`CLAUDE.md`,
  `.claude/rules/chezmoi.md`) and the `~/.zprofile.d/` drop-ins table
  (`documentation/shell-environment.md`)

Spec: `docs/superpowers/specs/2026-08-06-android-dev-support-design.md`
Plan: `docs/superpowers/plans/2026-08-06-android-dev-support.md`

## Manual step after merge + chezmoi apply

Launch Android Studio once; its setup wizard installs the SDK,
platform-tools and emulator into `~/Library/Android/sdk`.

## Follow-ups (deliberately out of scope)

- `README.md` Layer 5 tools table lacks Android (Swift also absent,
  pre-existing)
- Deployed `~/.claude/CLAUDE.md` Stack section lacks an Android entry
  (Swift also absent, precedent)
- No Kotlin editor/LSP integrations under `with_android` (`with_swift` has
  `swift-lsp`)
