### PR TITLE
chore: tooling audit semaine 34 2026

### DIFF
--- a/home/dot_vimrc.tmpl
+++ b/home/dot_vimrc.tmpl
@@ -181,8 +181,6 @@ function! NumberToggle()
   endif
 endfunc
 
-nnoremap <C-n> :call NumberToggle()<cr>
-
 augroup vimrcEx
   autocmd!
 
@@ -226,6 +224,10 @@ nnoremap <leader>a :Rg<Space>
 
 " Open fzf
 nnoremap <silent> <leader>f :FZF<CR>
+
+" Toggle relative line numbers
+" (<C-n> is claimed by vim-visual-multi's Find Under)
+nnoremap <leader>n :call NumberToggle()<CR>
 
 " toggle to paste mode
 nnoremap <silent> <leader>p :set paste!<CR>


### PR DESCRIPTION
## Contexte

Audit hebdomadaire (semaine ISO 34, 2026) de l'outillage installé par les dotfiles : formules/casks Homebrew et blocs conditionnels par feature flag, dépendances externes, plugins vim/tmux, extensions Cursor, et outils installés par les scripts `run_after` (npm globaux, serveurs MCP, plugins Claude, modèle Whisper).

Statuts de dépréciation Homebrew vérifiés sur métadonnées fraîches (`brew update`, Homebrew 6.0.15) ; dates de dernier push / archivage recoupées via `gh api` sur les 60+ repos upstream référencés ; extensions Cursor via l'API OpenVSX (flag `deprecated`) ; paquets npm via le registre.

**Sur l'axe maintenance, l'inventaire est intégralement sain cette semaine** : aucune formule ni cask déprécié/désactivé, aucun repo archivé, aucune référence morte. Le seul changement porte sur une **fonctionnalité cassée** — critère d'action explicite — héritée du remplacement de plugin acté en #81.

## Changements

- **fix(vim)** : `NumberToggle()` était **injoignable**. `vim-visual-multi` (introduit en #81 en remplacement de `terryma/vim-multiple-cursors`, déprécié) installe ses mappings depuis un hook `VimEnter`, donc **après** le source de `.vimrc` : il écrasait silencieusement `nnoremap <C-n> :call NumberToggle()`. Vérifié avant correction — `:verbose nmap <C-n>` renvoyait `<Plug>(VM-Find-Under)` *(Last set from `vim-visual-multi/autoload/vm/maps.vim`)*, et **aucun** mapping ne résolvait vers `NumberToggle()`.

  `<C-n>` reste attribué à vim-visual-multi (c'est l'attente documentée en #81) ; `NumberToggle()` passe sur `<leader>n` (`,n`), touche libre — les seuls mappings leader utilisés sont `,<Space> ,a ,f ,hp ,hs ,hu ,K ,p ,s`.

  Le mapping est **déplacé dans la section « Key Bindings »** : `<leader>` est résolu à la définition du mapping, et à son ancien emplacement il se situait *au-dessus* de `let mapleader = ','` — il aurait donc bindé `\n` au lieu de `,n`.

  Vérifié après correction sur le `.vimrc` rendu par chezmoi : `nmap ,n` → `:call NumberToggle()<CR>`, `nmap <C-n>` → `<Plug>(VM-Find-Under)`, syntaxe valide (`vim --noplugin -es -c quit`).

## Outils volontairement conservés

**Décisions déjà actées, non re-questionnées** (#80, #81, #82, #83) : `terminal-notifier` (upstream vivant en réalité — dernier push 2025-11-02), `insomnia` (cask bumpé 2026-07-24, v13.1.0), `yarn` 1.22.22, `license-checker`, `cost-of-modules`, et les plugins vim/tmux dormants.

- **karabiner-elements** ⚠️ : upstream actif (v16.1.0, 2026-07-05). L'issue de chargement du driver DriverKit **#4314 reste ouverte** et a été mise à jour le **2026-08-15** (machine locale en macOS **26.6.1**). Aucun successeur communautaire → conservé, **toujours sous surveillance**.
- **Plugins vim dormants** mais fonctionnels, purement locaux, sans enjeu de sécurité : `hhff/SpacegrayEighties.vim` (2015), `MarcWeber/vim-addon-mw-utils` (2020), `tomtom/tlib_vim` (2022), `ekalinin/Dockerfile.vim` (2022), `jremmen/vim-ripgrep` (2023), `aliou/bats.vim` (2023), `edkolev/tmuxline.vim` (2023), `easymotion/vim-easymotion` (2024), `mxw/vim-jsx` (2019). **Aucun archivé, aucun 404.**
- **Plugins tmux** : `tmux-online-status` (2023) et `tmux-sensible` (2024) dormants ; `resurrect` (2024), `yank` (2024), `open` (2024) OK.
- **Extensions Cursor dormantes** mais non dépréciées sur OpenVSX : `gruntfuggly.todo-tree` (2022-02), `mhutchie.git-graph` (2021-04), `tamasfe.even-better-toml` (2024-12), `ms-azuretools.vscode-docker` (2025-05).
- **Terraform / HashiCorp** : `hashicorp/tap/{terraform,nomad,consul,packer}` restent maintenus et non dépréciés. OpenTofu existe comme fork communautaire depuis le passage BUSL, mais Terraform n'est ni abandonné, ni incompatible, ni faillé → **pas de migration**, ce serait du churn.

## Constats sans action

- **Config vim morte** (inoffensive, aucune référence `Plug` cassée) : réglages `g:ctrlp_*` sans `ctrlp.vim` installé, et `autocmd User GoyoEnter/GoyoLeave` sans `junegunn/goyo.vim` (seul `limelight.vim` est présent). Vim ignore les variables inconnues et les événements `User` jamais déclenchés. Signalé, non corrigé — hors périmètre maintenance.
- **`MarcWeber/vim-addon-mw-utils` + `tomtom/tlib_vim`** sont les dépendances de `garbas/vim-snipmate`, qui n'est pas installé (le repo utilise `SirVer/ultisnips` + `honza/vim-snippets`). Elles ne servent donc à rien, mais ne cassent rien → conservées, cf. décision #81.
- **`bling/vim-airline`** résout toujours par redirection GitHub vers `vim-airline/vim-airline` (cf. #83). Redirection fonctionnelle → pas de churn.

## Reste de l'inventaire — sain

- **Homebrew** : **0 déprécié / 0 désactivé** sur 50 formules `homebrew/core`, 5 formules de tap (`hashicorp/tap` ×4, `ossianhempel/tap/things3-cli` v0.4.0) et 35 casks. Tous les fichiers de cask ont été bumpés récemment (le plus ancien : `font-hack`, 2025-08, une police).
- **Versions alignées sur l'upstream** : `ghostty` 1.3.1 = dernier tag ; `caffeine` 1.1.4 = dernière release ; `temurin@21` 21.0.12+8 = dernière GA de l'API Adoptium (flag `with_android` ajouté en #84, cask à jour).
- **Dépendances externes** : `tpm` **v3.1.0** et `vim-plug` **0.14.0** sont bien les derniers tags publiés ; `prezto` actif (2026-04-24).
- **npm globaux** (11) : aucun déprécié sur le registre, aucun repo archivé. `knip` 6.32.2 (successeur de depcheck acté en #83) actif.
- **Serveurs MCP** : `chrome-devtools-mcp` v1.7.0 (2026-08-10), `@upstash/context7-mcp` v4.0.2 (2026-08-11) — actifs.
- **Plugins Claude Code** : les 4 plugins référencés (`superpowers`, `frontend-design`, `rust-analyzer-lsp`, `swift-lsp`) sont **présents dans le manifeste** de `anthropics/claude-plugins-official` (286 plugins, push 2026-08-17) — périmètre jamais validé nom par nom auparavant. Marketplace `vbr-tech/eurosport-cc` actif, `eurosport` et `js-to-ts-converter` présents.
- **Extensions Cursor** : 22 extensions, **aucune `deprecated`** sur OpenVSX.
- **Node LTS** : `lts/jod` → v22.23.2, `lts/krypton` → v24.19.0. Aliases valides, Krypton reste le LTS actif.
- **whisper.cpp** : l'URL du modèle HuggingFace `ggerganov/whisper.cpp/ggml-medium.bin` répond toujours **HTTP 200**.

## ⚠️ Actions manuelles après merge

Aucun paquet Homebrew, aucune extension Cursor, aucun paquet npm n'est retiré cette semaine — **pas de `brew uninstall` ni de `npm uninstall -g` à prévoir**.

```bash
# 1. Appliquer
chezmoi apply -v

# 2. Recharger vim (aucun plugin ajouté/retiré, mais la config change)
#    Le nouveau mapping est actif au prochain lancement de vim.

# 3. Vérifier le mapping — ,n doit basculer les numéros de ligne,
#    <C-n> doit rester sur vim-visual-multi
vim -c 'verbose nmap ,n' -c 'verbose nmap <C-n>'
#    attendu : ,n    -> :call NumberToggle()<CR>
#              <C-N> -> <Plug>(VM-Find-Under)
```

**Rattrapage #81** — sur cette machine, `~/.vim/plugged` contient encore `vim-multiple-cursors` et `vim-bats`, les deux plugins remplacés en juillet : le `PlugClean!` des actions manuelles de #81 n'a jamais été passé. À faire ici et sur toute machine dans le même cas :

```bash
vim +PlugInstall +PlugClean! +qall
ls ~/.vim/plugged | grep -E 'vim-multiple-cursors|vim-bats'   # ne doit rien afficher
```

**Surveillance karabiner-elements** : issue #4314 (driver DriverKit) toujours ouverte et active au 2026-08-15. Vérifier que le driver charge après toute montée de version macOS.

À refaire sur chaque machine gérée par chezmoi.