### PR TITLE
chore: tooling audit semaine 35 2026

### DIFF
--- a/home/.chezmoiscripts/editors/run_onchange_after_cursor_extensions.sh.tmpl
+++ b/home/.chezmoiscripts/editors/run_onchange_after_cursor_extensions.sh.tmpl
@@ -28,7 +28,6 @@
 {{- if .with_docker -}}
 {{-   $extensions = concat $extensions (list
         "ms-azuretools.vscode-containers"
-        "ms-azuretools.vscode-docker"
     ) -}}
 {{- end -}}
 


### PR DESCRIPTION
## Contexte

Audit hebdomadaire (semaine ISO 35, 2026) de l'outillage installé par les dotfiles : formules et casks Homebrew (y compris tous les blocs conditionnels par feature flag), dépendances externes, plugins vim/tmux, extensions Cursor, et outils installés par les scripts `run_after` (npm globaux, serveurs MCP, plugins Claude, modèle Whisper, Node LTS, Rust).

Métadonnées Homebrew fraîches (`brew update`, Homebrew 6.0.17 ; API `formulae.brew.sh` : 8568 formules / 7702 casks). Statut d'archivage, dernier push et releases recoupés via `gh api` sur ~60 repos upstream. Extensions Cursor vérifiées sur **deux** registres (OpenVSX + VS Code Marketplace) — c'est ce double contrôle, croisé avec l'état du repo GitHub, qui a livré le seul vrai problème de la semaine. En complément, balayage des README upstream de tous les outils dormants à la recherche d'un avis de dépréciation explicite.

**Un seul changement.** Le reste est sain ou volontairement conservé.

## Changements

- **fix(cursor)** : suppression de `ms-azuretools.vscode-docker`. Le repo `microsoft/vscode-docker` a été **archivé le 2026-07-20** — quelques jours après le passage de l'audit semaine 29 (PR #82), qui l'avait légitimement trouvé sain. Son README s'ouvre désormais sur « *⚠️ Archived — Development has moved to microsoft/vscode-containers* » et précise que « *The Container Tools extension **replaces** the Docker extension [...] you can uninstall this extension pack, keeping only Container Tools* ».

  Depuis la v2.0.0 (2025-05-28, dernière release), l'extension n'est plus qu'un **extension pack dont le seul contenu est `ms-azuretools.vscode-containers`** — déjà installé par ce script. Aucun remplaçant à ajouter : retirer le pack archivé laisse exactement les mêmes fonctionnalités, plus le support Podman apporté par Container Tools. `microsoft/vscode-containers` est actif (dernier push 2026-08-21, v2.4.5).

  Ni OpenVSX ni le VS Code Marketplace ne portent de flag `deprecated` sur cette extension — seul l'état du repo GitHub le révèle.

## Outils volontairement conservés

**Bonne nouvelle — `karabiner-elements` sort de surveillance ✅.** Sous ⚠️ depuis l'audit de juillet (PR #81) puis semaine 29 (PR #82) à cause des issues de chargement du driver DriverKit sur macOS Tahoe : **les quatre issues bloquantes citées sont désormais fermées** — #4409 (2026-07-14), #4371 et #4376 (2026-07-20), et #4314 (**2026-08-22**, avant-hier). Il ne reste que 2 issues Tahoe ouvertes, toutes deux mineures et non bloquantes (#4537 réveil de veille, #4535 touches de luminosité sur Studio Display). Upstream actif (v16.1.0, 2026-07-05). Machines déjà en macOS 26.6.1.

**Décisions déjà actées, non re-questionnées** (PR #80 → #83) : `terminal-notifier`, `insomnia`, les npm globaux dormants (`license-checker` 2024-01, `cost-of-modules` 2023-07, `yarn` Classic 1.22.22), les extensions Cursor dormantes (`gruntfuggly.todo-tree`, `mhutchie.git-graph`, `tamasfe.even-better-toml`) et les plugins vim/tmux dormants. Aucun n'est archivé ni déprécié cette semaine.

**`mxw/vim-jsx` — décision de juillet confirmée par un test empirique.** Le plugin est explicitement marqué déprécié par son auteur (« *This package is deprecated! It apparently broke following changes to pangloss/vim-javascript circa early 2019* »), ce qui aurait pu justifier un remplacement. Vérification faite sur vim 9.2 avec la paire réellement installée (`pangloss/vim-javascript` + `mxw/vim-jsx`) : la coloration JSX **fonctionne** — `filetype=javascript.jsx`, régions `jsxRegion` correctes, balises en `xmlTag`/`xmlTagName`, attributs en `xmlAttrib`, expressions `{…}` résolues en `jsBlock`. Par ailleurs le successeur désigné, `MaxMEllon/vim-jsx-pretty`, est lui-même dormant (dernier commit 2021-01) : ce serait remplacer du dormant-mais-fonctionnel par du dormant. **Conservé**, conformément à la décision de PR #81 — à revoir si la coloration casse réellement.

À noter au passage : vim 9.2 embarque bien `syntax/javascriptreact.vim`, mais ce n'est qu'un stub (`runtime! syntax/javascript.vim`) sans support JSX réel — se reposer sur le natif n'est pas une option.

**Observation reconduite** (cf. PR #83) : `Plug 'bling/vim-airline'` résout par redirection GitHub vers `vim-airline/vim-airline` (actif, 2026-07-25). Fonctionnel, pas de churn.

## Reste de l'inventaire — sain

- **Homebrew** : **0 formule et 0 cask déprécié ou désactivé** sur les 50 formules et 35 casks référencés, tous blocs conditionnels inclus (`with_android`, `with_aws`, `with_docker`, `with_golang`, `with_javascript`, `with_consul`, `with_nomad`, `with_packer`, `with_php`, `with_rust`, `with_swift`, `with_terraform`, `project_eurosport`, `user_veberarnaud`, `user_emmett`, `has_*`).
- **Taps tiers** : `hashicorp/tap` (consul 2.0.2, nomad 2.0.4, packer 1.15.4, terraform 1.15.8) et `ossianhempel/tap` (things3-cli 0.4.0, push 2026-07-24) actifs.
- **Dépendances externes** : `tpm` **v3.1.0** et `vim-plug` **0.14.0** sont toujours les dernières versions taguées ; `prezto` actif (2026-04-24). Les modules prezto chargés (`osx`, `rails`, …) existent tous en amont.
- **Plugins vim (34) et tmux (6)** : aucun archivé, aucun 404, aucun avis de dépréciation hormis `mxw/vim-jsx` traité ci-dessus.
- **Extensions Cursor (21 après changement)** : aucune marquée `deprecated` sur OpenVSX ni sur le VS Code Marketplace.
- **npm globaux (11)** : aucun déprécié sur le registre, aucun repo archivé.
- **Serveurs MCP** : `chrome-devtools-mcp` v1.7.0 (2026-08-10) et `@upstash/context7-mcp` v4.0.3 (2026-08-21) — actifs.
- **Plugins Claude** : `superpowers`, `frontend-design`, `rust-analyzer-lsp`, `swift-lsp` tous présents dans `anthropics/claude-plugins-official` (push 2026-08-23).
- **Node LTS** : `lts/jod` (22) et `lts/krypton` (24, défaut) restent corrects — Krypton est le LTS actif jusqu'au 2026-10-20, Node 26 ne passera LTS que le 2026-10-28.
- **whisper.cpp** : l'URL du modèle HuggingFace `ggml-medium.bin` répond toujours **HTTP 200**.
- **Studio 3T Community Edition** : figée en 2025.1.0 depuis 13 mois, mais c'est bien la version courante en amont (édition gratuite non discontinuée, URL de téléchargement en 200, `auto_updates: true`). Pas d'action.
- **Aucun résidu** des outils retirés lors des audits précédents (`reattach-to-user-namespace`, `ctop`, `gpg-suite`, `depcheck`, `ndb`, `serayuzgur.crates`, `vim-multiple-cursors`, `markcornick/vim-bats`) dans les sources du repo.

## Vérification avant commit

Le template modifié a été rendu avec les données mock de la CI (`with_docker = true`) : `ms-azuretools.vscode-docker` a disparu, `ms-azuretools.vscode-containers` est conservé, 21 extensions au total, et le script rendu passe `shellcheck -s bash -e SC1091` sans avertissement.

## ⚠️ Actions manuelles après merge

Retirer une extension de la liste **ne la désinstalle pas** — `chezmoi apply` n'installe que ce qui est listé.

```bash
# 1. Appliquer
chezmoi apply -v

# 2. Désinstaller le pack archivé (non fait par chezmoi)
cursor --uninstall-extension ms-azuretools.vscode-docker

# 3. Vérifier : containers présent, docker absent
cursor --list-extensions | grep -E 'vscode-containers|vscode-docker'
# → doit afficher uniquement : ms-azuretools.vscode-containers

# 4. Recharger Cursor
#    (Cmd+Shift+P → "Developer: Reload Window")
```

Aucun paquet Homebrew, aucun plugin vim/tmux, aucun npm global n'est concerné cette semaine — pas de `brew uninstall`, pas de `PlugClean`, pas de service à recharger.

**Note d'hygiène (hors périmètre de cette PR)** : sur la machine de test, `~/.vim/plugged/` contient encore `vim-multiple-cursors` et `vim-bats`, retirés par la PR #81 — le `vim +PlugClean!` des actions manuelles de juillet n'a pas été passé partout. À rattraper :

```bash
vim +PlugInstall +PlugClean! +qall
```

**À refaire sur chaque machine gérée par chezmoi** — uniquement celles en `user_veberarnaud` + `with_docker` (Cursor n'est pas déployé sur les machines `user_emmett`).