### PR TITLE
feat(claude): use fable model alias instead of pinned model id

### DIFF
--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -48,7 +48,7 @@
     ],
     "defaultMode": "plan"
   },
-  "model": "claude-fable-5[1m]",
+  "model": "fable[1m]",
   "hooks": {
     "PermissionRequest": [
       {


### PR DESCRIPTION
## Summary

- Switch the Claude Code default model in `home/dot_claude/settings.json.tmpl` from the pinned ID `claude-fable-5[1m]` to the alias `fable[1m]`
- The alias resolves to the latest Fable model (currently Fable 5.1), so future model releases no longer require a "bump default model" commit
- Matches what `/model` writes to `~/.claude/settings.json`, keeping `chezmoi diff` clean after switching model from the CLI
- The `[1m]` suffix (1M context window) is preserved

https://claude.ai/code/session_01JCtDPzkQY45z9hFTFwXU1C