### PR TITLE
chore: tooling audit semaine 37 2026

### DIFF
--- a/home/.chezmoiscripts/tools/run_onchange_after_whisper_model.sh.tmpl
+++ b/home/.chezmoiscripts/tools/run_onchange_after_whisper_model.sh.tmpl
@@ -27,7 +27,7 @@ if [[ -f "${MODEL_FILE}" ]]; then
 else
     # Fetch expected checksum from HuggingFace API
     log_info "Fetching expected checksum from HuggingFace..."
-    expected_sha256=$(curl -sL "${MODEL_SHA256_URL}" | jq -r ".[] | select(.rfilename == \"${MODEL_NAME}\") | .lfs.sha256" 2>/dev/null || true)
+    expected_sha256=$(curl -sL "${MODEL_SHA256_URL}" | jq -r ".[] | select(.path == \"${MODEL_NAME}\") | .lfs.oid // empty" 2>/dev/null || true)
 
     log_info "Downloading whisper medium model (~1.5 GiB)..."
     retry curl -L --progress-bar -o "${MODEL_FILE}" "${MODEL_URL}"


### PR DESCRIPTION
## Contexte

Audit hebdomadaire (semaine ISO 37, 2026) de l'outillage installé par les dotfiles : formules et casks Homebrew (tous blocs conditionnels par feature flag inclus), dépendances externes, plugins vim/tmux, extensions Cursor, et outils installés par les scripts `run_after` (npm globaux, serveurs MCP, plugins Claude, modèle Whisper, Node LTS, Rust).

Métadonnées Homebrew fraîches (`brew update`, Homebrew 6.0.22 ; API `formulae.brew.sh` : 8588 formules / 7724 casks). Statut d'archivage et dernier push recoupés via `gh api` sur ~80 repos upstream. Extensions Cursor vérifiées sur **deux** registres (OpenVSX + VS Code Marketplace) *et* sur l'état du repo GitHub — c'est ce triple contrôle qui avait livré le problème de la semaine 35. Balayage des README upstream de tous les outils dormants à la recherche d'un avis de dépréciation.

**Sur l'axe maintenance, l'inventaire est intégralement sain cette semaine** : aucune formule ni cask déprécié/désactivé, aucun repo archivé, aucune référence morte, aucune extension dépréciée. Le seul changement porte sur une **fonctionnalité cassée avec une dimension sécurité** — critère d'action explicite — dans le script Whisper, sur un périmètre que les audits précédents n'avaient vérifié qu'en surface (« l'URL répond 200 »).

## Changements

- **fix(whisper)** : la vérification SHA-256 du modèle de 1,5 Gio était **silencieusement désactivée** depuis un moment — le filtre `jq` lisait deux champs que l'API HuggingFace ne renvoie pas.

  L'endpoint utilisé, `/api/models/<id>/tree/main`, retourne des entrées clefées sur **`path`**, pas `rfilename` (`rfilename` n'existe que dans `siblings[]` sur l'endpoint `/api/models/<id>`, qui lui ne porte aucun checksum). Le `select(.rfilename == ...)` ne matchait donc **rien**, `expected_sha256` ressortait vide, et le script partait systématiquement dans sa branche `log_warn \"Could not fetch expected checksum — skipping verification\"`. Seul le contrôle de taille (> 1 Gio) subsistait : un binaire de 1,5 Gio téléchargé sur le réseau puis exécuté par `whisper-cli` sans aucune vérification d'intégrité.

  Le champ de checksum était lui aussi erroné : l'API expose **`lfs.oid`** et `xetHash`, jamais `lfs.sha256`. Vérifié empiriquement sur `ggml-tiny-q5_1.bin` (32 Mio, même repo, téléchargement réel) : `lfs.oid` est **exactement** le SHA-256 du contenu (`818710568da3ca15…`). `xetHash` est le hash de déduplication Xet et n'est pas utilisable ici.

  Ajout de `// empty` : si le champ est renommé un jour, le script retombe sur la branche warn-and-skip existante au lieu de produire la chaîne littérale `\"null\"` — qui échouerait la comparaison et **supprimerait un téléchargement valide de 1,5 Gio**.

  Avant / après, sur l'API réelle :

  \`\`\`
  ancien filtre → expected_sha256=''                     (vérification sautée)
  nouveau       → expected_sha256='6c14d5adee5f8639…'    (vérification exécutée)
  \`\`\`

  Au passage : `ggerganov/whisper.cpp` reste bien le bon repo HuggingFace. Le repo GitHub a migré vers l'org `ggml-org` (et la formule `whisper-cpp` v1.9.2 pointe déjà dessus), mais `ggml-org/whisper.cpp` **n'existe pas** sur HuggingFace (401). Aucun changement d'URL à faire.

## Outils volontairement conservés

**Décisions déjà actées, non re-questionnées** (PR #80 → #86) : `terminal-notifier` (upstream bien vivant — push 2026-08-30), `insomnia`, `yarn` Classic 1.22.22, `license-checker` (2024-01), `cost-of-modules` (2023-07), Terraform vs OpenTofu (pas de migration), et les plugins vim/tmux dormants. Aucun n'est archivé ni déprécié cette semaine.

- **`mxw/vim-jsx`** : toujours le seul outil de l'inventaire portant un avis de dépréciation explicite dans son README. Décision de #86 reconduite — la coloration JSX fonctionne, le successeur désigné est lui-même dormant. Conservé.
- **`karabiner-elements` ✅ confirmé sorti de surveillance.** Sorti du ⚠️ en #86 ; l'upstream vient de publier **v16.3.0 (2026-09-06, hier)** et le cask est déjà aligné en 16.3.0. Recherche d'issues : **0 issue Tahoe ouverte**. Machine en macOS 26.6.1. Rien à surveiller.
- **Plugins vim dormants** mais fonctionnels, purement locaux, sans enjeu de sécurité : `hhff/SpacegrayEighties.vim` (2015), `mxw/vim-jsx` (2019), `MarcWeber/vim-addon-mw-utils` (2020), `tomtom/tlib_vim` (2022), `ekalinin/Dockerfile.vim` (2022), `jremmen/vim-ripgrep` (2023), `aliou/bats.vim` (2023), `edkolev/tmuxline.vim` (2023), `easymotion/vim-easymotion` (2024). **Aucun archivé, aucun 404, aucun avis de dépréciation nouveau.**
- **Plugins tmux** : `tmux-online-status` (2023) et `tmux-sensible` (2024) dormants ; `resurrect` (2024), `yank` (2024), `open` (2024) OK.
- **Extensions Cursor dormantes** mais non dépréciées sur les deux registres : `gruntfuggly.todo-tree`, `mhutchie.git-graph`, `tamasfe.even-better-toml`.
- **Observation reconduite** (cf. #83, #86) : `Plug 'bling/vim-airline'` résout toujours par redirection GitHub vers `vim-airline/vim-airline` (actif, push 2026-08-27). Fonctionnel → pas de churn.

## Constat sans action

Le fallback warn-and-skip du script Whisper (« checksum introuvable → on télécharge quand même ») est précisément ce qui a permis à ce bug de passer inaperçu : aucune sortie d'erreur, juste un `[WARN]` noyé dans un `chezmoi apply`. Le `// empty` ajouté ici protège contre la variante destructrice du problème, mais le comportement « on continue sans vérifier » reste. Le durcir en échec franc rendrait `chezmoi apply` dépendant de la joignabilité de l'API HuggingFace — hors périmètre de cet audit, signalé pour décision.

## Reste de l'inventaire — sain

- **Homebrew** : **0 formule et 0 cask déprécié ou désactivé** sur les 50 formules et 35 casks référencés, tous blocs conditionnels inclus (`with_android`, `with_aws`, `with_docker`, `with_golang`, `with_javascript`, `with_consul`, `with_nomad`, `with_packer`, `with_php`, `with_rust`, `with_swift`, `with_terraform`, `project_eurosport`, `user_veberarnaud`, `user_emmett`, `has_*`). Tous les tokens résolvent, y compris `claude-code@latest` et `temurin@21`.
- **Upstreams des paquets brew hébergés sur GitHub (20)** : aucun archivé. Notamment `julienXX/terminal-notifier` (2026-08-30), `joshmedeski/sesh` (2026-09-04), `jesseduffield/lazydocker` (2026-04-19), `Nike-Inc/gimme-aws-creds` (2026-06-02), `openai/codex` (2026-09-07).
- **Taps tiers** : `hashicorp/tap` (consul 2.0.3, nomad 2.0.5, packer 1.16.0, terraform 1.16.0) et `ossianhempel/tap/things3-cli` (0.4.0) actifs, non dépréciés.
- **Dépendances externes** : `tpm` **v3.1.0** et `vim-plug` **0.14.0** restent les derniers tags publiés (vérifié sur la liste des tags/releases) ; `prezto` actif (2026-04-24). Les 18 modules prezto chargés (`archive`, `osx`, `rails`, `gnu-utility`, …) existent tous en amont.
- **Plugins vim (33) et tmux (6)** : aucun archivé, aucun désactivé, aucun 404.
- **Extensions Cursor (21)** : aucune `deprecated` sur OpenVSX, aucune dépubliée sur le VS Code Marketplace (toutes `validated, public`), **aucun repo upstream archivé**.
- **npm globaux (11)** : aucun déprécié sur le registre, aucun repo archivé. `knip` 6.34.0, `pnpm` 12.3.4, `npm-check-updates` 23.1.0 tous récents.
- **Serveurs MCP** : `chrome-devtools-mcp` v1.8.0 (2026-08-25) et `@upstash/context7-mcp` v4.0.5 (2026-09-04) — actifs, non dépréciés.
- **Plugins Claude** : `superpowers`, `frontend-design`, `rust-analyzer-lsp`, `swift-lsp` tous présents dans le manifeste de `anthropics/claude-plugins-official` (291 plugins, push 2026-09-05). Marketplace `vbr-tech/eurosport-cc` actif, `eurosport` et `js-to-ts-converter` présents.
- **Node LTS** : `lts/jod` → v22.23.2, `lts/krypton` → v24.20.0 (défaut). Aliases valides ; Node 26.8.1 est la dernière *current*, pas encore LTS. Rien à changer avant fin octobre.
- **Rust** : `rustup` non déprécié, composants `rustfmt`/`clippy`/`rust-analyzer` inchangés.
- **Aucun résidu** des outils retirés lors des audits précédents (`reattach-to-user-namespace`, `ctop`, `gpg-suite`, `depcheck`, `ndb`, `serayuzgur.crates`, `vim-multiple-cursors`, `markcornick/vim-bats`, `ms-azuretools.vscode-docker`) dans les sources du repo.

## Vérification avant commit

- `chezmoi diff` : rendu sans erreur, le script Whisper apparaît bien comme pending.
- Les 16 templates `*.sh.tmpl` rendus et passés à `shellcheck -s bash -e SC1091` : **aucun avertissement** (équivalent CI).
- `bash -n` sur le script Whisper rendu : OK.
- Filtre `jq` corrigé testé **contre l'API réelle** : renvoie `6c14d5adee5f86394037b4e4e8b59f1673b6cee10e3cf0b11bbdbee79c156208` pour `ggml-medium.bin` (l'ancien renvoyait une chaîne vide).
- Équivalence `lfs.oid` ≡ SHA-256 du contenu **prouvée par téléchargement réel** d'un fichier du même repo.

## ⚠️ Actions manuelles après merge

Aucun paquet Homebrew, aucune extension Cursor, aucun paquet npm, aucun plugin vim/tmux n'est retiré cette semaine — **pas de `brew uninstall`, pas de `npm uninstall -g`, pas de `PlugClean` à prévoir**.

Le script Whisper est un `run_onchange_` : son contenu ayant changé, il **se relancera** au prochain `chezmoi apply`. Il ne re-téléchargera rien si `ggml-medium.bin` est déjà présent (test `-f` en tête) — la correction ne prendra donc effet que lors d'un futur téléchargement.

```bash
# 1. Appliquer (machines user_emmett uniquement — le script est guardé dessus)
chezmoi apply -v

# 2. Vérifier que le filtre corrigé renvoie bien un checksum (doit afficher 64 hex)
curl -sL "https://huggingface.co/api/models/ggerganov/whisper.cpp/tree/main" \
  | jq -r '.[] | select(.path == "ggml-medium.bin") | .lfs.oid // empty'

# 3. Contrôler l'intégrité du modèle DÉJÀ téléchargé — il n'a jamais été vérifié
shasum -a 256 ~/.local/share/whisper-cpp/models/ggml-medium.bin
#    doit afficher : 6c14d5adee5f86394037b4e4e8b59f1673b6cee10e3cf0b11bbdbee79c156208
#    en cas de divergence : rm le fichier puis relancer `chezmoi apply --force`
#    pour un re-téléchargement, cette fois réellement vérifié
```

L'étape 3 est la seule qui compte vraiment : sur toute machine où le modèle a déjà été téléchargé, il l'a été **sans vérification d'intégrité**. C'est l'occasion de la faire une fois a posteriori.

Aucun service à recharger.

**À refaire sur chaque machine gérée par chezmoi** — en pratique uniquement celles en `user_emmett`, seules concernées par le flag du script Whisper.