### PR TITLE
feat(ssh): support ProxyJump and LocalForward fields in config.local template

### DIFF
--- a/home/dot_ssh/private_config.local.tmpl
+++ b/home/dot_ssh/private_config.local.tmpl
@@ -6,12 +6,16 @@
 {{- $user := "" }}
 {{- $aliases := list }}
 {{- $port := "22" }}
+{{- $proxyJump := "" }}
+{{- $localForwards := list }}
 {{- $identityFile := "~/.ssh/id_ed25519" }}
 {{- range $item.fields }}
 {{- if eq .label "HostName" }}{{ $hostname = .value }}{{ end }}
 {{- if eq .label "User" }}{{ $user = .value }}{{ end }}
 {{- if and (eq .label "aliases") .value }}{{ $aliases = append $aliases .value }}{{ end }}
 {{- if and (eq .label "Port") .value }}{{ $port = .value }}{{ end }}
+{{- if and (eq .label "ProxyJump") .value }}{{ $proxyJump = .value }}{{ end }}
+{{- if and (eq .label "LocalForward") .value }}{{ $localForwards = append $localForwards .value }}{{ end }}
 {{- if and (eq .label "IdentityFile") .value }}{{ $identityFile = .value }}{{ end }}
 {{- end }}
 # {{ $item.title }}
@@ -19,6 +23,12 @@ Host {{ $item.title }}{{ if $aliases }} {{ $aliases | join " " }}{{ end }}
     HostName {{ $hostname }}
     User {{ $user }}
     Port {{ $port }}
+{{- if $proxyJump }}
+    ProxyJump {{ $proxyJump }}
+{{- end }}
+{{- range $localForwards }}
+    LocalForward {{ . }}
+{{- end }}
     IdentityFile {{ $identityFile }}
     AddKeysToAgent yes
     UseKeychain yes


### PR DESCRIPTION
## Summary

- Read two new optional fields from the 1Password Server items tagged `ssh-config`: `ProxyJump` (single value) and `LocalForward` (repeatable, same pattern as `aliases`).
- `ProxyJump` is emitted after `Port`, `LocalForward` lines right after it; items without these fields render exactly as before.
- Motivation: remote-access entries (a LAN host reached through a Tailscale bastion, a Screen Sharing tunnel) can now live in 1Password instead of being hand-edited into `~/.ssh/config.local` and overwritten on the next `chezmoi apply`.

## Test plan

- [x] `chezmoi cat ~/.ssh/config.local` renders existing items unchanged (block-by-block comparison, 13 items)
- [x] Item with `ProxyJump` renders a single `ProxyJump` line; `ssh -G` resolves `proxyjump` only for that host and not for aliases of sibling entries
- [x] Item with `LocalForward` renders the `LocalForward` line; `ssh -G` shows `localforward 5900 [localhost]:5900`
- [x] Real connection through the jump host from outside the LAN, and VNC reachable on `127.0.0.1:5900` through the tunnel

https://claude.ai/code/session_01X9k2ujmatXt4BKtMETd5sW